### PR TITLE
use future to fund seeds in another thread

### DIFF
--- a/CaptureSight-Overlay/source/ui/PokemonSummaryLayout.cpp
+++ b/CaptureSight-Overlay/source/ui/PokemonSummaryLayout.cpp
@@ -55,7 +55,9 @@ void PokemonSummaryLayout::AddBodyDrawer(u16 x, u16 y, tsl::Screen* screen) {
 
 bool PokemonSummaryLayout::FindRaidSeed(s64 keys) {
   if (keys == KEY_A) {
-    this->seed = this->pkm->GetRaidSeed();
+    auto seedFuture = this->pkm->GetRaidSeedAsync();
+    seedFuture.wait();
+    this->seed = seedFuture.get();
     this->changeTo(new RaidSearchLayout(this->seed, 5));
     this->shouldSearchForSeed = false;
     return true;

--- a/libcsight/include/csight/CalculateRaidSeed.hpp
+++ b/libcsight/include/csight/CalculateRaidSeed.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <vector>
+#include <future>
 #include <switch.h>
 
 namespace csight {
   namespace raid {
+    std::future<ulong> CalculateRaidSeedAsync(uint ec, uint pid, std::vector<s8> ivs);
     ulong CalculateRaidSeed(uint ec, uint pid, std::vector<s8> ivs);
   }  // namespace raid
 }  // namespace csight

--- a/libcsight/include/csight/PK8.hpp
+++ b/libcsight/include/csight/PK8.hpp
@@ -2,6 +2,7 @@
 
 #include <switch.h>
 #include <vector>
+#include <future>
 #include <string>
 
 namespace csight {
@@ -52,6 +53,7 @@ namespace csight {
     u8 GetOTFriendship();
     u8 GetCurrentFriendship();
     ulong GetRaidSeed();
+    std::future<ulong> GetRaidSeedAsync();
 
    private:
     u8* data = new u8[0x148];

--- a/libcsight/source/csight/CalculateRaidSeed.cpp
+++ b/libcsight/source/csight/CalculateRaidSeed.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <vector>
+#include <future>
 #include <csight/RaidPokemon.hpp>
 
 u64 rotateLeft(u64 first, u64 second) {
@@ -30,7 +31,7 @@ namespace csight {
       temp_low = temp_low ^ (temp_low << 16);
 
       // Test the bytes that impact the PID most
-      // By picking only the most impactul bytes, we avoid unneeded iterations
+      // By picking only the most impactful bytes, we avoid unneeded iterations
       // TODO: choose most impactful bits
       for (u64 i = 0; i <= 0xFF; i++) {
         for (u64 j = 0; j <= 0xFF; j++) {
@@ -63,6 +64,10 @@ namespace csight {
       }
 
       return 0;
+    }
+
+    std::future<u64> CalculateRaidSeedAsync(u32 ec, u32 pid, std::vector<s8> ivs) {
+      return std::async(&csight::raid::CalculateRaidSeed, ec, pid, ivs);
     }
   }  // namespace raid
 }  // namespace csight

--- a/libcsight/source/csight/PK8.cpp
+++ b/libcsight/source/csight/PK8.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <future>
 #include <csight/PK8.hpp>
 #include <csight/RNG.hpp>
 #include <csight/CalculateRaidSeed.hpp>
@@ -201,4 +202,6 @@ namespace csight {
   u8 PK8::GetCurrentFriendship() { return this->GetCurrentHandler() == 0 ? this->GetOTFriendship() : this->GetHTFriendship(); }
 
   ulong PK8::GetRaidSeed() { return raid::CalculateRaidSeed(this->GetEncryptionConstant(), this->GetPID(), this->GetIVs()); }
+
+  std::future<ulong> PK8::GetRaidSeedAsync() { return raid::CalculateRaidSeedAsync(this->GetEncryptionConstant(), this->GetPID(), this->GetIVs()); }
 }  // namespace csight


### PR DESCRIPTION
Adresses #21.

I used C++ futures to calculate raid seed in async for the overlay. Now the game does not freeze when calculating the raid seed. Also due to a bug in tesla (or a weird interaction with capturesight overlay), hitting home button and then going back to the game gives control back to the player and you can actually play the game while the seed is being calculated.

I also did the same with the applet, but async calculation there does not change anything so I didn't include it in this pull request.

For both, maybe we can include a moving "calculating" icon so that it gives some confidence that the overlay/applet has not frozen?