### PR TITLE
Fix RaidSeedButton text after calculation

### DIFF
--- a/src/views/swsh/wild-trade-raid-view.hpp
+++ b/src/views/swsh/wild-trade-raid-view.hpp
@@ -18,7 +18,7 @@ class RaidSeedButton : public Button {
       auto pk8 = read_pk8();
       auto raid_seed = pk8->FindRaidSeed();
       std::string new_label = raid_seed.has_value() ? utils::num_to_hex(raid_seed.value()) : "None";
-      this->setText(utils::num_to_hex(new_label));
+      this->setText(new_label);
     });
   }
 };


### PR DESCRIPTION
The seed was being turned into a hex string and then the string was attempted to be put as a hex string again.